### PR TITLE
usb-reflash: Drop dd conv=sparse usage

### DIFF
--- a/eos-usb-reflash/99reflash/shutdown.sh
+++ b/eos-usb-reflash/99reflash/shutdown.sh
@@ -19,7 +19,7 @@ IS_DUAL_IMAGE=false
 # if the dd succeeds.
 flash_device () {
     dd bs=1M if=/dev/zero of=$1 count=1 conv=fsync || return 1
-    gzip -cd $2 | pv | dd bs=1M of=$1 iflag=fullblock conv=sparse seek=1 skip=1 || return 1
+    gzip -cd $2 | pv | dd bs=1M of=$1 iflag=fullblock seek=1 skip=1 || return 1
     # when dd exits it causes a broken pipe on gzip's end, so we ignore that err
     gzip -cd $2 2>/dev/null | dd bs=1M of=$1 count=1 iflag=fullblock conv=fsync || return 1
 


### PR DESCRIPTION
Per dd(1):
  sparse  try to seek rather than write the output for NUL input blocks

While providing a minor optimization, this means that the device is not
byte-for-byte equivalent to the image file. This has been shown to cause
ostree fsck failures where files fail checksums because there may be old
data where ther should be NULs.

[endlessm/eos-shell#4949]
